### PR TITLE
feat(members): add upcoming_birthdays endpoint to retrieve members wi…

### DIFF
--- a/backend/apps/members/services.py
+++ b/backend/apps/members/services.py
@@ -1,0 +1,36 @@
+from datetime import timedelta, date
+from django.utils import timezone
+from .models import Member
+
+def _next_annual_occurrence(d: date, today: date):
+    """Return the next occurrence date (this year or next) for month/day of d."""
+    if d is None:
+        return None
+    try:
+        occ = date(today.year, d.month, d.day)
+    except ValueError:
+        # handle Feb 29 -> fallback to Mar 1
+        occ = date(today.year, 3, 1)
+    if occ < today:
+        try:
+            occ = date(today.year + 1, d.month, d.day)
+        except ValueError:
+            occ = date(today.year + 1, 3, 1)
+    return occ
+
+def get_upcoming_birthdays(days=7):
+    """
+    Return list of dicts: {'member': Member, 'occurrence': date}
+    for birthdays occurring in the next `days` days (including today).
+    """
+    today = timezone.localdate()
+    deadline = today + timedelta(days=days)
+    results = []
+    # simple approach: iterate members (ok for small/medium datasets)
+    for m in Member.objects.all():
+        occ = _next_annual_occurrence(m.date_of_birth, today)
+        if occ and today <= occ <= deadline:
+            results.append({'member': m, 'occurrence': occ})
+    # optional: sort by occurrence date
+    results.sort(key=lambda r: r['occurrence'])
+    return results


### PR DESCRIPTION
This pull request introduces a new feature to the members app that allows users to retrieve upcoming member birthdays via the API. The main changes include implementing the logic to calculate upcoming birthdays, exposing a new endpoint, and integrating the service into the viewset.

**New Feature: Upcoming Birthdays API**

* Adds a utility function to calculate upcoming birthdays for members within a specified number of days.
* Introduces a new API endpoint `/api/members/upcoming_birthdays/` in the `MemberViewSet` to return members with birthdays in the next N days.
* Imports and integrates the new `get_upcoming_birthdays` service function into the members view logic.…th upcoming birthdays