### PR TITLE
Feature/member management

### DIFF
--- a/backend/apps/members/services.py
+++ b/backend/apps/members/services.py
@@ -34,3 +34,20 @@ def get_upcoming_birthdays(days=7):
     # optional: sort by occurrence date
     results.sort(key=lambda r: r['occurrence'])
     return results
+
+def get_upcoming_anniversaries(days=7):
+    """
+    Return list of dicts: {'member': Member, 'occurrence': date}
+    for anniversaries occurring in the next `days` days (including today).
+    """
+    today = timezone.localdate()
+    deadline = today + timedelta(days=days)
+    results = []
+    # simple approach: iterate members (ok for small/medium datasets)
+    for m in Member.objects.all():
+        occ = _next_annual_occurrence(m.baptism_date, today)
+        if occ and today <= occ <= deadline:
+            results.append({'member': m, 'occurrence': occ})
+    # optional: sort by occurrence date
+    results.sort(key=lambda r: r['occurrence'])
+    return results

--- a/backend/apps/members/views.py
+++ b/backend/apps/members/views.py
@@ -8,7 +8,7 @@ from django.db import transaction
 
 from .models import Member
 from .serializers import MemberSerializer
-from .services import get_upcoming_birthdays
+from .services import get_upcoming_birthdays, get_upcoming_anniversaries
 
 
 class MemberViewSet(viewsets.ModelViewSet):
@@ -129,6 +129,25 @@ class MemberViewSet(viewsets.ModelViewSet):
         except ValueError:
             days = 7
         reminders = get_upcoming_birthdays(days=days)
+        data = []
+        for r in reminders:
+            ser = self.get_serializer(r['member'])
+            item = ser.data
+            item['occurrence_date'] = r['occurrence'].isoformat()
+            data.append(item)
+        return Response(data, status=status.HTTP_200_OK)
+    
+    @action(detail=False, methods=['get'], permission_classes=[permissions.IsAuthenticated])
+    def upcoming_anniversaries(self, request):
+        """
+        GET /api/members/upcoming_anniversaries/?days=7
+        Returns members with anniversaries in the next `days` days (default 7).
+        """
+        try:
+            days = int(request.query_params.get('days', 7))
+        except ValueError:
+            days = 7
+        reminders = get_upcoming_anniversaries(days=days)
         data = []
         for r in reminders:
             ser = self.get_serializer(r['member'])


### PR DESCRIPTION
This pull request adds support for listing upcoming member anniversaries (such as baptisms) within a given number of days, similar to the existing birthdays feature. The new functionality includes a service method to compute upcoming anniversaries and an API endpoint to retrieve them.

New anniversaries functionality:

* Added a `get_upcoming_anniversaries` function in `services.py` to compute members with anniversaries (based on `baptism_date`) within the next specified number of days.
* Imported `get_upcoming_anniversaries` in `views.py` to make it available for use in the viewset.
* Added an `upcoming_anniversaries` action to the `MemberViewSet`, providing a new API endpoint (`/api/members/upcoming_anniversaries/`) that returns members with upcoming anniversaries, supporting an optional `days` query parameter.