### PR TITLE
fix: Improve pagination handling in useMembers hook

### DIFF
--- a/frontend/src/features/members/hooks/useMembers.js
+++ b/frontend/src/features/members/hooks/useMembers.js
@@ -59,11 +59,11 @@ export const useMembers = () => {
 
         setMembers(filteredResults);
         setPagination({
-          count: filteredResults.length, // Use filtered count
+          count: data.count,
           next: data.next,
           previous: data.previous,
           currentPage: page,
-          totalPages: Math.ceil(filteredResults.length / 10),
+          totalPages: Math.ceil(data.count / 10),
         });
       } else {
         // Fallback for non-paginated response


### PR DESCRIPTION
## Description
<!-- What does this PR do? Why is it needed? -->
This pull request updates the member pagination logic in the `useMembers` hook to use the total count from the backend response instead of the filtered results count. This ensures that the pagination reflects the actual number of members available, not just those currently displayed.

* Pagination state in `useMembers.js` now uses `data.count` from the backend response for both `count` and `totalPages`, improving accuracy for paginated member lists.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Quick Checklist
- [x] Code tested locally
- [x] No warnings or errors
- [x] Follows project structure (`backend/apps/`, `frontend/src/`)
- [x] No `__pycache__`, `.env`, or `node_modules` committed
- [ ] Database migrations tested (if applicable)
- [ ] Updated documentation (if needed)

## For Major Changes Only
<details>
<summary>Click if this is a significant feature or breaking change</summary>

### Implementation Details
- Files changed:
- PRD section implemented:
- Completion: %

### Potential Issues
- What could break:

### Testing Done
- [ ] Tested on development
- [ ] Tested edge cases
- [ ] No existing functionality broken

</details>

## Screenshots
<!-- Add screenshots for UI changes -->

---
**⚠️ Critical Rules:**
- No commits to root directory (except docs/)
- No hard-coded credentials
- All apps in `backend/apps/`

**📝 Note:** @emperuna reviews all changes
