### PR TITLE
Add Dockerfiles for backend and frontend with multi-stage builds for development and production

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,59 @@
+# Backend Dockerfile for Django API
+# Multi-stage: dev (with hot reload) & prod (gunicorn)
+
+# ---------- Base image ----------
+FROM python:3.12-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=on \
+    PIP_DEFAULT_TIMEOUT=100
+
+WORKDIR /app
+
+# System deps (psycopg2, build, etc.)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       build-essential \
+       libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install python deps
+COPY backend/requirements.txt ./requirements.txt
+RUN pip install --upgrade pip setuptools wheel \
+    && pip install -r requirements.txt
+
+# App source
+COPY backend /app
+
+# Default envs (override in compose)
+ENV DJANGO_SETTINGS_MODULE=sbcc.settings \
+    PYTHONPATH=/app
+
+
+# ---------- Development image ----------
+FROM base AS dev
+
+# Create non-root user
+RUN useradd -m appuser
+USER appuser
+
+EXPOSE 8000
+
+# Run Django dev server with autoreload
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+
+
+# ---------- Production image ----------
+FROM base AS prod
+
+RUN pip install gunicorn
+
+# Create non-root user
+RUN useradd -m appuser
+USER appuser
+
+EXPOSE 8000
+
+CMD ["gunicorn", "sbcc.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "3"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+      target: dev
+    container_name: sbcc-backend
+    env_file:
+      - backend/.env
+    environment:
+      # Ensure Django binds to 0.0.0.0 and uses correct port
+      - DJANGO_SETTINGS_MODULE=sbcc.settings
+    volumes:
+      - ./backend:/app
+    ports:
+      - "8000:8000"
+    depends_on: []
+
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+      target: dev
+    container_name: sbcc-frontend
+    environment:
+      - VITE_API_BASE_URL=http://backend:8000/api
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+
+networks:
+  default:
+    name: sbcc-network

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,39 @@
+# Frontend Dockerfile for Vite + React
+# Multi-stage: dev (hot reload) & prod (static build)
+
+# ---------- Base node image ----------
+FROM node:22-alpine AS base
+
+WORKDIR /app
+
+# Install dependencies
+COPY frontend/package.json frontend/package-lock.json* ./
+RUN npm install
+
+COPY frontend .
+
+
+# ---------- Development image ----------
+FROM base AS dev
+
+EXPOSE 5173
+
+# Vite dev server with HMR, listening on all interfaces
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]
+
+
+# ---------- Production build ----------
+FROM base AS build
+
+RUN npm run build
+
+
+# ---------- Production Nginx image ----------
+FROM nginx:1.27-alpine AS prod
+
+# Copy built static files
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Description
<!-- What does this PR do? Why is it needed? -->
This pull request sets up Docker-based development and production environments for both the backend (Django API) and frontend (Vite + React) applications. It introduces multi-stage Dockerfiles for efficient builds, and a `docker-compose.yml` file to orchestrate both services, enabling seamless local development and deployment.

**Containerization and orchestration setup:**

* Added `backend/Dockerfile` with multi-stage builds for development (hot reload with Django dev server) and production (using Gunicorn), including installation of system and Python dependencies.
* Added `frontend/Dockerfile` with multi-stage builds for development (Vite dev server with HMR) and production (static build served by Nginx).
* Introduced `docker-compose.yml` to orchestrate backend and frontend services, configure environment variables, bind ports, mount code directories for live reload, and define a shared Docker network.
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Quick Checklist
- [ ] Code tested locally
- [ ] No warnings or errors
- [ ] Follows project structure (`backend/apps/`, `frontend/src/`)
- [ ] No `__pycache__`, `.env`, or `node_modules` committed
- [ ] Database migrations tested (if applicable)
- [ ] Updated documentation (if needed)

## For Major Changes Only
<details>
<summary>Click if this is a significant feature or breaking change</summary>

### Implementation Details
- Files changed:
- PRD section implemented:
- Completion: %

### Potential Issues
- What could break:

### Testing Done
- [ ] Tested on development
- [ ] Tested edge cases
- [ ] No existing functionality broken

</details>

## Screenshots
<!-- Add screenshots for UI changes -->

---
**⚠️ Critical Rules:**
- No commits to root directory (except docs/)
- No hard-coded credentials
- All apps in `backend/apps/`

**📝 Note:** @emperuna reviews all changes
