### PR TITLE
Add errorhandling for backend deployment

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -15,5 +15,11 @@ jobs:
 
     steps:
       - name: Deploy to Render
+        env:
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
         run: |
-          curl -X POST "${{ secrets.RENDER_DEPLOY_HOOK_URL }}"
+          if [ -z "$RENDER_DEPLOY_HOOK_URL" ]; then
+            echo "Error: RENDER_DEPLOY_HOOK_URL secret is not set"
+            exit 1
+          fi
+          curl -X POST "$RENDER_DEPLOY_HOOK_URL"


### PR DESCRIPTION
## Description
<!-- What does this PR do? Why is it needed? -->
This pull request makes a small improvement to the deployment workflow by adding error handling for the deploy hook secret. The change ensures that the deployment step fails with a clear error message if the `RENDER_DEPLOY_HOOK_URL` secret is not set.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Quick Checklist
- [ ] Code tested locally
- [ ] No warnings or errors
- [ ] Follows project structure (`backend/apps/`, `frontend/src/`)
- [ ] No `__pycache__`, `.env`, or `node_modules` committed
- [ ] Database migrations tested (if applicable)
- [ ] Updated documentation (if needed)

## For Major Changes Only
<details>
<summary>Click if this is a significant feature or breaking change</summary>

### Implementation Details
- Files changed:
- PRD section implemented:
- Completion: %

### Potential Issues
- What could break:

### Testing Done
- [ ] Tested on development
- [ ] Tested edge cases
- [ ] No existing functionality broken

</details>

## Screenshots
<!-- Add screenshots for UI changes -->

---
**⚠️ Critical Rules:**
- No commits to root directory (except docs/)
- No hard-coded credentials
- All apps in `backend/apps/`

**📝 Note:** @emperuna reviews all changes
