### PR TITLE
Fix render file for deployment

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -15,5 +15,11 @@ jobs:
 
     steps:
       - name: Deploy to Render
+        env:
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
         run: |
-          curl -X POST "${{ secrets.RENDER_DEPLOY_HOOK_URL }}"
+          if [ -z "$RENDER_DEPLOY_HOOK_URL" ]; then
+            echo "Error: RENDER_DEPLOY_HOOK_URL secret is not set"
+            exit 1
+          fi
+          curl -X POST "$RENDER_DEPLOY_HOOK_URL"

--- a/render.yaml
+++ b/render.yaml
@@ -3,9 +3,8 @@ services:
     name: sbcc-backend
     runtime: docker
     dockerfilePath: ./backend/Dockerfile
-    dockerContext: .
-    dockerTarget: prod
-    region: singapore  # or oregon, frankfurt, ohio
+    dockerContext: ./backend
+    region: sin
     plan: free
     healthCheckPath: /api/health/
     envVars:
@@ -16,9 +15,9 @@ services:
       - key: DEBUG
         value: "False"
       - key: SECRET_KEY
-        sync: false  # Set manually in dashboard
+        sync: false
       - key: DATABASE_URL
-        sync: false  # Set manually in dashboard
+        sync: false
       - key: ALLOWED_HOSTS
         sync: false
       - key: CORS_ALLOWED_ORIGINS


### PR DESCRIPTION
## Description
<!-- What does this PR do? Why is it needed? -->
This pull request updates deployment configuration for the backend service, focusing on improving reliability and aligning settings with platform requirements. The most important changes include enhanced error handling for deployment secrets and adjustments to the Render service configuration.

**Deployment workflow improvements:**

* Added a check to ensure the `RENDER_DEPLOY_HOOK_URL` secret is set before attempting deployment in `.github/workflows/deploy-backend.yml`, providing clearer error messaging and preventing silent failures.

**Render service configuration updates:**

* Changed the Docker context for the backend service in `render.yaml` from `.` to `./backend`, ensuring the correct build context is used.
* Removed the unused `dockerTarget: prod` setting and updated the deployment region from `singapore` to the region code `sin` for compatibility with Render's requirements.
* Cleaned up comments in the environment variable section of `render.yaml` for `SECRET_KEY` and `DATABASE_URL` to improve clarity.
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Quick Checklist
- [ ] Code tested locally
- [ ] No warnings or errors
- [ ] Follows project structure (`backend/apps/`, `frontend/src/`)
- [ ] No `__pycache__`, `.env`, or `node_modules` committed
- [ ] Database migrations tested (if applicable)
- [ ] Updated documentation (if needed)

## For Major Changes Only
<details>
<summary>Click if this is a significant feature or breaking change</summary>

### Implementation Details
- Files changed:
- PRD section implemented:
- Completion: %

### Potential Issues
- What could break:

### Testing Done
- [ ] Tested on development
- [ ] Tested edge cases
- [ ] No existing functionality broken

</details>

## Screenshots
<!-- Add screenshots for UI changes -->

---
**⚠️ Critical Rules:**
- No commits to root directory (except docs/)
- No hard-coded credentials
- All apps in `backend/apps/`

**📝 Note:** @emperuna reviews all changes
