### PR TITLE
Add missing dockerTarget configuration in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,6 +4,7 @@ services:
     runtime: docker
     dockerfilePath: ./backend/Dockerfile
     dockerContext: .
+    dockerTarget: prod
     region: singapore
     plan: free
     healthCheckPath: /api/health/


### PR DESCRIPTION
This pull request makes a minor configuration update to the deployment settings in `render.yaml`. The change specifies the Docker build target for the backend service.

* Deployment configuration: Set the `dockerTarget` to `prod` for the backend service in `render.yaml`, ensuring the production build stage is used during deployment.