### PR TITLE
Add dockerTarget on render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,6 +4,7 @@ services:
     runtime: docker
     dockerfilePath: ./backend/Dockerfile
     dockerContext: .
+    dockerTarget: prod
     region: singapore
     plan: free
     healthCheckPath: /api/health/


### PR DESCRIPTION
## Description
<!-- What does this PR do? Why is it needed? -->
This pull request makes a small configuration change to the deployment setup. The `dockerTarget` property is now explicitly set to `prod` for the backend service in `render.yaml`. This ensures that the production build stage is used when deploying the backend service.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Quick Checklist
- [ ] Code tested locally
- [ ] No warnings or errors
- [ ] Follows project structure (`backend/apps/`, `frontend/src/`)
- [ ] No `__pycache__`, `.env`, or `node_modules` committed
- [ ] Database migrations tested (if applicable)
- [ ] Updated documentation (if needed)

## For Major Changes Only
<details>
<summary>Click if this is a significant feature or breaking change</summary>

### Implementation Details
- Files changed:
- PRD section implemented:
- Completion: %

### Potential Issues
- What could break:

### Testing Done
- [ ] Tested on development
- [ ] Tested edge cases
- [ ] No existing functionality broken

</details>

## Screenshots
<!-- Add screenshots for UI changes -->

---
**⚠️ Critical Rules:**
- No commits to root directory (except docs/)
- No hard-coded credentials
- All apps in `backend/apps/`

**📝 Note:** @emperuna reviews all changes
