### PR TITLE
Switches to python3 and adds pip for consistent installs

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,8 +1,8 @@
 [phases.setup]
-nixPkgs = ["python312", "postgresql"]
+nixPkgs = ["python312", "python312Packages.pip", "postgresql"]
 
 [phases.install]
-cmds = ["cd backend && pip install -r requirements.txt && pip install gunicorn"]
+cmds = ["cd backend && python3 -m pip install -r requirements.txt"]
 
 [start]
-cmd = "cd backend && python manage.py migrate --noinput && python manage.py collectstatic --noinput && gunicorn sbcc.wsgi:application --bind 0.0.0.0:$PORT"
+cmd = "cd backend && python3 manage.py migrate --noinput && python3 manage.py collectstatic --noinput && gunicorn sbcc.wsgi:application --bind 0.0.0.0:$PORT"


### PR DESCRIPTION
### Motivation

- Ensures consistent use of python3 for all backend commands and package installations.
- Adds pip explicitly to the environment, preventing missing package issues during setup.

### Benefits

- Avoids ambiguity between python versions and pip executables.
- Reduces deployment errors by guaranteeing required tools are available.
- Simplifies installation workflow by using `python3 -m pip`.

Relates to future compatibility and reliability improvements.