### PR TITLE
Add public API endpoints for announcements, events, prayer requests, and settings

### DIFF
--- a/backend/apps/announcements/public_views.py
+++ b/backend/apps/announcements/public_views.py
@@ -1,0 +1,86 @@
+"""
+Public API views for announcements.
+No authentication required - for homepage consumption.
+"""
+
+from django.db.models import Q
+from django.utils import timezone
+from rest_framework import serializers
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .models import Announcement
+
+
+class PublicAnnouncementSerializer(serializers.ModelSerializer):
+    """Lightweight serializer for public announcement display."""
+
+    ministry_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Announcement
+        fields = [
+            "id",
+            "title",
+            "body",
+            "audience",
+            "ministry_name",
+            "publish_at",
+            "expire_at",
+            "created_at",
+        ]
+
+    def get_ministry_name(self, obj):
+        return obj.ministry.name if obj.ministry else None
+
+
+class PublicAnnouncementsView(APIView):
+    """
+    GET /api/public/announcements/
+
+    Public endpoint for fetching published announcements.
+    No authentication required.
+
+    Query Parameters:
+        ministry (int): Optional filter by ministry ID
+        limit (int): Max number of results (default: 10, max: 50)
+    """
+
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        now = timezone.now()
+
+        # Base queryset: active, published, not expired
+        queryset = (
+            Announcement.objects.select_related("ministry")
+            .filter(is_active=True, publish_at__lte=now)
+            .filter(Q(expire_at__isnull=True) | Q(expire_at__gt=now))
+        )
+
+        # Filter by ministry if provided
+        ministry_id = request.query_params.get("ministry")
+        if ministry_id:
+            queryset = queryset.filter(
+                Q(audience="all") | Q(audience="ministry", ministry_id=ministry_id)
+            )
+        else:
+            # If no ministry specified, only return "all" audience announcements
+            queryset = queryset.filter(audience="all")
+
+        # Apply limit
+        try:
+            limit = min(int(request.query_params.get("limit", 10)), 50)
+        except (ValueError, TypeError):
+            limit = 10
+
+        queryset = queryset.order_by("-publish_at")[:limit]
+
+        serializer = PublicAnnouncementSerializer(queryset, many=True)
+        return Response(
+            {
+                "count": len(serializer.data),
+                "results": serializer.data,
+            }
+        )

--- a/backend/apps/events/public_views.py
+++ b/backend/apps/events/public_views.py
@@ -1,0 +1,97 @@
+"""
+Public API views for events.
+No authentication required - for homepage consumption.
+"""
+
+from django.utils import timezone
+from rest_framework import serializers
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .models import Event
+
+
+class PublicEventSerializer(serializers.ModelSerializer):
+    """Lightweight serializer for public event display."""
+
+    ministry_name = serializers.SerializerMethodField()
+    organizer_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Event
+        fields = [
+            "id",
+            "title",
+            "description",
+            "event_type",
+            "date",
+            "end_date",
+            "location",
+            "ministry_name",
+            "organizer_name",
+            "max_attendees",
+            "registered_count",
+            "available_slots",
+            "is_full",
+        ]
+
+    def get_ministry_name(self, obj):
+        return obj.ministry.name if obj.ministry else None
+
+    def get_organizer_name(self, obj):
+        if obj.organizer:
+            name = f"{obj.organizer.first_name} {obj.organizer.last_name}".strip()
+            return name or obj.organizer.username
+        return None
+
+
+class PublicEventsView(APIView):
+    """
+    GET /api/public/events/
+
+    Public endpoint for fetching upcoming published events.
+    No authentication required.
+
+    Query Parameters:
+        event_type (str): Optional filter by event type (service, bible_study, etc.)
+        ministry (int): Optional filter by ministry ID
+        limit (int): Max number of results (default: 10, max: 50)
+    """
+
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        now = timezone.now()
+
+        # Base queryset: published and upcoming
+        queryset = Event.objects.select_related("ministry", "organizer").filter(
+            status="published",
+            date__gte=now,
+        )
+
+        # Filter by event_type if provided
+        event_type = request.query_params.get("event_type")
+        if event_type:
+            queryset = queryset.filter(event_type=event_type)
+
+        # Filter by ministry if provided
+        ministry_id = request.query_params.get("ministry")
+        if ministry_id:
+            queryset = queryset.filter(ministry_id=ministry_id)
+
+        # Apply limit
+        try:
+            limit = min(int(request.query_params.get("limit", 10)), 50)
+        except (ValueError, TypeError):
+            limit = 10
+
+        queryset = queryset.order_by("date")[:limit]
+
+        serializer = PublicEventSerializer(queryset, many=True)
+        return Response(
+            {
+                "count": len(serializer.data),
+                "results": serializer.data,
+            }
+        )

--- a/backend/apps/prayer_requests/public_views.py
+++ b/backend/apps/prayer_requests/public_views.py
@@ -1,0 +1,85 @@
+"""
+Public API views for prayer requests.
+No authentication required - for homepage consumption.
+"""
+
+from rest_framework import serializers, status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .models import PrayerRequest
+
+
+class PublicPrayerRequestSubmitSerializer(serializers.Serializer):
+    """Serializer for public prayer request submission."""
+
+    title = serializers.CharField(max_length=255)
+    description = serializers.CharField()
+    category = serializers.ChoiceField(
+        choices=PrayerRequest.CATEGORY_CHOICES,
+        default="other",
+    )
+    requester_name = serializers.CharField(max_length=100, required=False, allow_blank=True)
+    requester_email = serializers.EmailField(required=False, allow_blank=True)
+    requester_phone = serializers.CharField(max_length=15, required=False, allow_blank=True)
+    is_anonymous = serializers.BooleanField(default=False)
+
+    def validate(self, data):
+        """Validate that name is provided if not anonymous."""
+        if not data.get("is_anonymous") and not data.get("requester_name"):
+            raise serializers.ValidationError(
+                {"requester_name": "Name is required unless submitting anonymously."}
+            )
+        return data
+
+    def create(self, validated_data):
+        """Create a new prayer request."""
+        return PrayerRequest.objects.create(
+            title=validated_data["title"],
+            description=validated_data["description"],
+            category=validated_data.get("category", "other"),
+            requester_name=validated_data.get("requester_name", ""),
+            requester_email=validated_data.get("requester_email", ""),
+            requester_phone=validated_data.get("requester_phone", ""),
+            is_anonymous=validated_data.get("is_anonymous", False),
+            status="pending",
+        )
+
+
+class PublicPrayerRequestSubmitView(APIView):
+    """
+    POST /api/public/prayer-requests/submit/
+
+    Public endpoint for submitting prayer requests.
+    No authentication required.
+
+    Request Body:
+        title (str): Prayer request title (required)
+        description (str): Prayer request details (required)
+        category (str): Category code (optional, default: "other")
+        requester_name (str): Requester name (required unless anonymous)
+        requester_email (str): Requester email (optional)
+        requester_phone (str): Requester phone (optional)
+        is_anonymous (bool): Submit anonymously (optional, default: false)
+    """
+
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        serializer = PublicPrayerRequestSubmitSerializer(data=request.data)
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        prayer_request = serializer.save()
+
+        return Response(
+            {
+                "message": "Prayer request submitted successfully.",
+                "id": prayer_request.id,
+                "title": prayer_request.title,
+                "status": prayer_request.status,
+            },
+            status=status.HTTP_201_CREATED,
+        )

--- a/backend/sbcc/public_urls.py
+++ b/backend/sbcc/public_urls.py
@@ -1,0 +1,26 @@
+"""
+Public API URL configuration.
+All endpoints require no authentication.
+"""
+
+from django.urls import path
+
+from apps.announcements.public_views import PublicAnnouncementsView
+from apps.events.public_views import PublicEventsView
+from apps.prayer_requests.public_views import PublicPrayerRequestSubmitView
+from apps.settings.views import PublicSettingsView
+
+urlpatterns = [
+    # System settings (branding, contact, about)
+    path("settings/", PublicSettingsView.as_view(), name="public-settings"),
+    # Announcements
+    path("announcements/", PublicAnnouncementsView.as_view(), name="public-announcements"),
+    # Prayer requests submission
+    path(
+        "prayer-requests/submit/",
+        PublicPrayerRequestSubmitView.as_view(),
+        name="public-prayer-request-submit",
+    ),
+    # Events
+    path("events/", PublicEventsView.as_view(), name="public-events"),
+]

--- a/backend/sbcc/urls.py
+++ b/backend/sbcc/urls.py
@@ -10,8 +10,6 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 
-from apps.settings.urls import public_urlpatterns as settings_public_urls
-
 urlpatterns = [
     path("admin/", admin.site.urls),
     # Authentication
@@ -31,7 +29,7 @@ urlpatterns = [
     # Dashboard (aggregates data from multiple apps)
     path("api/dashboard/", include("core.urls")),
     # Public APIs (no auth required)
-    path("api/public/", include(settings_public_urls)),
+    path("api/public/", include("sbcc.public_urls")),
 ]
 
 # Serve media files in development

--- a/backend/tests/test_public_api.py
+++ b/backend/tests/test_public_api.py
@@ -1,0 +1,282 @@
+"""
+Tests for public API endpoints.
+These endpoints require no authentication.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+
+from apps.announcements.models import Announcement
+from apps.events.models import Event
+from apps.ministries.models import Ministry
+from apps.prayer_requests.models import PrayerRequest
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+@pytest.fixture
+def ministry(db):
+    """Create a test ministry."""
+    return Ministry.objects.create(name="Test Ministry", is_active=True)
+
+
+@pytest.fixture
+def published_announcement(db):
+    """Create a published announcement."""
+    return Announcement.objects.create(
+        title="Published Announcement",
+        body="This is a public announcement.",
+        audience="all",
+        is_active=True,
+        publish_at=timezone.now() - timedelta(hours=1),
+    )
+
+
+@pytest.fixture
+def future_announcement(db):
+    """Create a future (not yet published) announcement."""
+    return Announcement.objects.create(
+        title="Future Announcement",
+        body="This will be published later.",
+        audience="all",
+        is_active=True,
+        publish_at=timezone.now() + timedelta(days=1),
+    )
+
+
+@pytest.fixture
+def expired_announcement(db):
+    """Create an expired announcement."""
+    return Announcement.objects.create(
+        title="Expired Announcement",
+        body="This has expired.",
+        audience="all",
+        is_active=True,
+        publish_at=timezone.now() - timedelta(days=2),
+        expire_at=timezone.now() - timedelta(days=1),
+    )
+
+
+@pytest.fixture
+def published_event(db, user):
+    """Create a published upcoming event."""
+    return Event.objects.create(
+        title="Upcoming Event",
+        description="A public event.",
+        event_type="service",
+        status="published",
+        date=timezone.now() + timedelta(days=7),
+        location="Main Hall",
+        organizer=user,
+    )
+
+
+@pytest.fixture
+def past_event(db, user):
+    """Create a past event."""
+    return Event.objects.create(
+        title="Past Event",
+        description="Already happened.",
+        event_type="service",
+        status="published",
+        date=timezone.now() - timedelta(days=7),
+        location="Main Hall",
+        organizer=user,
+    )
+
+
+@pytest.fixture
+def user(db, django_user_model):
+    """Create a test user."""
+    return django_user_model.objects.create_user(
+        username="testuser",
+        email="test@example.com",
+        password="testpass123",
+        role="admin",
+    )
+
+
+# =============================================================================
+# Public Announcements Tests
+# =============================================================================
+@pytest.mark.django_db
+class TestPublicAnnouncementsAPI:
+    """Tests for GET /api/public/announcements/"""
+
+    def test_no_auth_required(self, api_client, published_announcement):
+        """Test that endpoint is accessible without authentication."""
+        url = reverse("public-announcements")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "results" in response.data
+        assert "count" in response.data
+
+    def test_returns_only_published_announcements(
+        self, api_client, published_announcement, future_announcement
+    ):
+        """Test that only currently published announcements are returned."""
+        url = reverse("public-announcements")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        titles = [a["title"] for a in response.data["results"]]
+
+        assert "Published Announcement" in titles
+        assert "Future Announcement" not in titles
+
+    def test_excludes_expired_announcements(
+        self, api_client, published_announcement, expired_announcement
+    ):
+        """Test that expired announcements are excluded."""
+        url = reverse("public-announcements")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        titles = [a["title"] for a in response.data["results"]]
+
+        assert "Published Announcement" in titles
+        assert "Expired Announcement" not in titles
+
+    def test_limit_parameter(self, api_client, published_announcement):
+        """Test the limit query parameter."""
+        url = reverse("public-announcements")
+        response = api_client.get(url, {"limit": 5})
+
+        assert response.status_code == status.HTTP_200_OK
+
+
+# =============================================================================
+# Public Prayer Request Submission Tests
+# =============================================================================
+@pytest.mark.django_db
+class TestPublicPrayerRequestSubmitAPI:
+    """Tests for POST /api/public/prayer-requests/submit/"""
+
+    def test_no_auth_required_for_anonymous(self, api_client):
+        """Test that anonymous submissions work without authentication."""
+        url = reverse("public-prayer-request-submit")
+        response = api_client.post(
+            url,
+            {
+                "title": "Anonymous Prayer",
+                "description": "Please pray for me.",
+                "category": "other",
+                "is_anonymous": True,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["message"] == "Prayer request submitted successfully."
+        assert PrayerRequest.objects.filter(title="Anonymous Prayer").exists()
+
+    def test_submit_with_name_and_email(self, api_client):
+        """Test submission with requester contact info."""
+        url = reverse("public-prayer-request-submit")
+        response = api_client.post(
+            url,
+            {
+                "title": "Named Prayer Request",
+                "description": "Please pray for my family.",
+                "category": "family",
+                "requester_name": "John Doe",
+                "requester_email": "john@example.com",
+                "is_anonymous": False,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        pr = PrayerRequest.objects.get(title="Named Prayer Request")
+        assert pr.requester_name == "John Doe"
+        assert pr.requester_email == "john@example.com"
+        assert pr.status == "pending"
+
+    def test_name_required_if_not_anonymous(self, api_client):
+        """Test that name is required for non-anonymous submissions."""
+        url = reverse("public-prayer-request-submit")
+        response = api_client.post(
+            url,
+            {
+                "title": "Missing Name",
+                "description": "No name provided.",
+                "is_anonymous": False,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "requester_name" in response.data
+
+    def test_validates_required_fields(self, api_client):
+        """Test that required fields are validated."""
+        url = reverse("public-prayer-request-submit")
+        response = api_client.post(url, {}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "title" in response.data
+        assert "description" in response.data
+
+
+# =============================================================================
+# Public Events Tests
+# =============================================================================
+@pytest.mark.django_db
+class TestPublicEventsAPI:
+    """Tests for GET /api/public/events/"""
+
+    def test_no_auth_required(self, api_client, published_event):
+        """Test that endpoint is accessible without authentication."""
+        url = reverse("public-events")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "results" in response.data
+        assert "count" in response.data
+
+    def test_returns_only_upcoming_published_events(self, api_client, published_event, past_event):
+        """Test that only upcoming published events are returned."""
+        url = reverse("public-events")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        titles = [e["title"] for e in response.data["results"]]
+
+        assert "Upcoming Event" in titles
+        assert "Past Event" not in titles
+
+    def test_filter_by_event_type(self, api_client, published_event):
+        """Test filtering by event type."""
+        url = reverse("public-events")
+        response = api_client.get(url, {"event_type": "service"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["results"]) == 1
+
+        # Test non-matching type
+        response = api_client.get(url, {"event_type": "outreach"})
+        assert len(response.data["results"]) == 0
+
+
+# =============================================================================
+# Public Settings Tests
+# =============================================================================
+@pytest.mark.django_db
+class TestPublicSettingsAPI:
+    """Tests for GET /api/public/settings/"""
+
+    def test_no_auth_required(self, api_client):
+        """Test that endpoint is accessible without authentication."""
+        url = reverse("public-settings")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "app_name" in response.data
+        assert "church_name" in response.data


### PR DESCRIPTION
Adds a set of unauthenticated public API endpoints to expose site settings, announcements, events, and a prayer request submission surface so the homepage and other public consumers can retrieve and submit content without authentication.

### Why
- Provide a lightweight, read-only surface for front-end consumption of public content (settings, announcements, upcoming events).
- Allow external users to submit prayer requests without requiring an account.
- Centralize public routes under a single URL configuration to simplify inclusion in the main URL tree.
- Improve test coverage to ensure the public endpoints behave correctly (visibility, filtering, validation).

### Key points
- Introduces public endpoints that require no authentication and are optimized for homepage consumption.
- Ensures announcements are filtered to currently published, non-expired items and supports ministry-scoped filtering and a configurable limit.
- Exposes upcoming published events with optional filtering by type and ministry, ordered by date.
- Adds a submission endpoint for prayer requests with validation (name required unless anonymous) and creates pending prayer records.
- Adds a top-level public URL config and plugs it into the main URL patterns.
- Adds comprehensive tests covering accessibility, filtering behavior, validation, and successful submissions.

### Benefits
- Enables public-facing UI to fetch only relevant, safe content without exposing internal admin functionality.
- Simplifies integration for static or server-rendered homepages and external services.
- Reduces risk of returning unpublished or expired content to the public.
- Provides a secure, validated path for anonymous or named prayer request submissions.

No issue reference.