### PR TITLE
Improve email notification handling and add rotation tests

### DIFF
--- a/backend/apps/ministries/utils.py
+++ b/backend/apps/ministries/utils.py
@@ -189,7 +189,7 @@ def rotate_and_assign(
                                             else:
                                                 summary["skipped_no_email"] += 1
                                                 print("    ⚠️ Email skipped (no address)")
-                                        except TimeoutError as timeout_err:
+                                        except TimeoutError:
                                             print(
                                                 "    ⚠️ Email timeout - SMTP connection slow/blocked"
                                             )

--- a/backend/sbcc/email_backend.py
+++ b/backend/sbcc/email_backend.py
@@ -16,8 +16,11 @@ class CustomEmailBackend(EmailBackend):
         if self.connection:
             return False
 
+        # Use a shorter timeout (10s) to prevent worker timeouts
+        timeout = self.timeout if self.timeout else 10
+
         try:
-            self.connection = smtplib.SMTP(self.host, self.port, timeout=self.timeout)
+            self.connection = smtplib.SMTP(self.host, self.port, timeout=timeout)
 
             # Create SSL context that skips certificate verification
             context = ssl.create_default_context()

--- a/backend/tests/ministries/__init__.py
+++ b/backend/tests/ministries/__init__.py
@@ -1,0 +1,1 @@
+# Test package for ministries app

--- a/backend/tests/ministries/conftest.py
+++ b/backend/tests/ministries/conftest.py
@@ -1,0 +1,122 @@
+from datetime import date, time, timedelta
+
+import pytest
+from django.utils import timezone
+
+
+@pytest.fixture
+def member_with_email(db):
+    """Create a Member with an email address."""
+    from apps.members.models import Member
+
+    return Member.objects.create(
+        first_name="John",
+        last_name="Doe",
+        email="john.doe@example.com",
+        phone="1234567890",
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def member_without_email(db):
+    """Create a Member without an email address."""
+    from apps.members.models import Member
+
+    return Member.objects.create(
+        first_name="Jane",
+        last_name="Smith",
+        email="",  # No email
+        phone="0987654321",
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def test_ministry(db, ministry_leader_user):
+    """Create a test ministry."""
+    from apps.ministries.models import Ministry
+
+    return Ministry.objects.create(
+        name="Test Music Ministry",
+        description="Test ministry for rotation tests",
+        leader=ministry_leader_user,
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def ministry_member_with_email(db, test_ministry, member_with_email):
+    """Create a MinistryMember linking a member with email to a ministry."""
+    from apps.ministries.models import MinistryMember
+
+    return MinistryMember.objects.create(
+        member=member_with_email,
+        ministry=test_ministry,
+        role="volunteer",
+        is_active=True,
+        available_days=["Sunday", "Saturday"],
+        max_consecutive_shifts=3,
+    )
+
+
+@pytest.fixture
+def ministry_member_without_email(db, test_ministry, member_without_email):
+    """Create a MinistryMember linking a member without email to a ministry."""
+    from apps.ministries.models import MinistryMember
+
+    return MinistryMember.objects.create(
+        member=member_without_email,
+        ministry=test_ministry,
+        role="volunteer",
+        is_active=True,
+        available_days=["Sunday"],
+        max_consecutive_shifts=2,
+    )
+
+
+@pytest.fixture
+def upcoming_shift(db, test_ministry):
+    """Create a shift for the upcoming Sunday."""
+    from apps.ministries.models import Shift
+
+    # Find next Sunday
+    today = timezone.now().date()
+    days_until_sunday = (6 - today.weekday()) % 7
+    if days_until_sunday == 0:
+        days_until_sunday = 7  # If today is Sunday, get next Sunday
+    next_sunday = today + timedelta(days=days_until_sunday)
+
+    return Shift.objects.create(
+        ministry=test_ministry,
+        date=next_sunday,
+        start_time=time(9, 0),
+        end_time=time(12, 0),
+        notes="Sunday morning service",
+    )
+
+
+@pytest.fixture
+def multiple_weekend_shifts(db, test_ministry):
+    """Create multiple unassigned weekend shifts for testing rotation (matches volunteer availability)."""
+    from apps.ministries.models import Shift
+
+    today = timezone.now().date()
+    shifts = []
+
+    # Create shifts only on weekends (Saturday=5, Sunday=6)
+    for i in range(1, 22):  # Look ahead 3 weeks to find enough weekend days
+        shift_date = today + timedelta(days=i)
+        if shift_date.weekday() in [5, 6]:  # Saturday or Sunday
+            shift = Shift.objects.create(
+                ministry=test_ministry,
+                date=shift_date,
+                start_time=time(9, 0),
+                end_time=time(12, 0),
+                notes=f"Weekend Shift on {shift_date.strftime('%A')}",
+            )
+            shifts.append(shift)
+            if len(shifts) >= 5:  # Create at least 5 weekend shifts
+                break
+
+    return shifts

--- a/backend/tests/ministries/test_rotation.py
+++ b/backend/tests/ministries/test_rotation.py
@@ -1,0 +1,208 @@
+"""
+Tests for ministry shift rotation and email notification functionality.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from apps.ministries.models import Assignment
+from apps.ministries.utils import rotate_and_assign
+
+
+# =============================================================================
+# Rotation Utility Tests
+# =============================================================================
+@pytest.mark.django_db
+class TestRotateAndAssign:
+    """Tests for the rotate_and_assign utility function."""
+
+    def test_rotation_creates_assignments(
+        self, test_ministry, ministry_member_with_email, upcoming_shift
+    ):
+        """Test that rotation creates assignments for unassigned shifts."""
+        summary = rotate_and_assign(
+            ministry_ids=[test_ministry.id],
+            days=14,
+            dry_run=False,
+            notify=False,
+        )
+
+        assert summary["created"] == 1
+        assert summary["emailed"] == 0
+        assert Assignment.objects.filter(shift=upcoming_shift).exists()
+
+    def test_rotation_dry_run_no_changes(
+        self, test_ministry, ministry_member_with_email, upcoming_shift
+    ):
+        """Test that dry run doesn't create actual assignments."""
+        summary = rotate_and_assign(
+            ministry_ids=[test_ministry.id],
+            days=14,
+            dry_run=True,
+            notify=False,
+        )
+
+        assert summary["created"] == 1  # Would be created
+        assert not Assignment.objects.filter(shift=upcoming_shift).exists()
+
+    def test_rotation_skips_ministry_with_no_members(self, test_ministry, upcoming_shift):
+        """Test that rotation skips ministries with no active members."""
+        summary = rotate_and_assign(
+            ministry_ids=[test_ministry.id],
+            days=14,
+            dry_run=False,
+            notify=False,
+        )
+
+        assert summary["created"] == 0
+        assert test_ministry.id in summary["skipped_no_members"]
+
+    @patch("apps.ministries.utils.send_mail")
+    def test_rotation_sends_email_when_notify_true(
+        self, mock_send_mail, test_ministry, ministry_member_with_email, upcoming_shift
+    ):
+        """Test that email is sent when notify=True and member has email."""
+        summary = rotate_and_assign(
+            ministry_ids=[test_ministry.id],
+            days=14,
+            dry_run=False,
+            notify=True,
+        )
+
+        assert summary["created"] == 1
+        assert summary["emailed"] == 1
+        assert summary["skipped_no_email"] == 0
+        mock_send_mail.assert_called_once()
+
+    @patch("apps.ministries.utils.send_mail")
+    def test_rotation_tracks_skipped_no_email(
+        self, mock_send_mail, test_ministry, ministry_member_without_email, upcoming_shift
+    ):
+        """Test that rotation tracks when emails are skipped due to missing address."""
+        summary = rotate_and_assign(
+            ministry_ids=[test_ministry.id],
+            days=14,
+            dry_run=False,
+            notify=True,
+        )
+
+        assert summary["created"] == 1
+        assert summary["emailed"] == 0
+        assert summary["skipped_no_email"] == 1
+        mock_send_mail.assert_not_called()
+
+    @patch("apps.ministries.utils.send_mail")
+    def test_rotation_handles_email_failure(
+        self, mock_send_mail, test_ministry, ministry_member_with_email, upcoming_shift
+    ):
+        """Test that rotation handles email sending failures gracefully."""
+        mock_send_mail.side_effect = Exception("SMTP connection failed")
+
+        summary = rotate_and_assign(
+            ministry_ids=[test_ministry.id],
+            days=14,
+            dry_run=False,
+            notify=True,
+        )
+
+        assert summary["created"] == 1
+        assert summary["emailed"] == 0
+        assert len(summary["errors"]) == 1
+        assert "SMTP connection failed" in summary["errors"][0]
+
+    def test_rotation_respects_limit_per_ministry(
+        self, test_ministry, ministry_member_with_email, multiple_weekend_shifts
+    ):
+        """Test that rotation respects the limit_per_ministry parameter."""
+        summary = rotate_and_assign(
+            ministry_ids=[test_ministry.id],
+            days=30,
+            dry_run=False,
+            notify=False,
+            limit_per_ministry=3,
+        )
+
+        assert summary["created"] == 3
+        assert Assignment.objects.filter(shift__ministry=test_ministry).count() == 3
+
+
+# =============================================================================
+# API Endpoint Tests
+# =============================================================================
+@pytest.mark.django_db
+class TestRotateShiftsAPI:
+    """Tests for the rotate_shifts API endpoint."""
+
+    def test_rotate_shifts_requires_authentication(self, api_client, test_ministry):
+        """Test that the endpoint requires authentication."""
+        url = reverse("ministry-rotate-shifts", kwargs={"pk": test_ministry.id})
+        response = api_client.post(url, {}, format="json")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_rotate_shifts_as_admin(
+        self, admin_client, test_ministry, ministry_member_with_email, upcoming_shift
+    ):
+        """Test that admin can rotate shifts."""
+        url = reverse("ministry-rotate-shifts", kwargs={"pk": test_ministry.id})
+        response = admin_client.post(
+            url,
+            {"days": 14, "dry_run": True, "notify": False},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "created" in response.data
+
+    def test_rotate_shifts_as_pastor(
+        self, pastor_client, test_ministry, ministry_member_with_email, upcoming_shift
+    ):
+        """Test that pastor can rotate shifts."""
+        url = reverse("ministry-rotate-shifts", kwargs={"pk": test_ministry.id})
+        response = pastor_client.post(
+            url,
+            {"days": 14, "dry_run": True, "notify": False},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "created" in response.data
+
+    def test_rotate_shifts_returns_skipped_no_email(
+        self, admin_client, test_ministry, ministry_member_without_email, upcoming_shift
+    ):
+        """Test that API response includes skipped_no_email count."""
+        url = reverse("ministry-rotate-shifts", kwargs={"pk": test_ministry.id})
+        response = admin_client.post(
+            url,
+            {"days": 14, "dry_run": False, "notify": True},
+            format="json",
+        )
+
+        assert response.status_code in [status.HTTP_200_OK, status.HTTP_207_MULTI_STATUS]
+        assert "skipped_no_email" in response.data
+        assert response.data["skipped_no_email"] == 1
+
+    @patch("apps.ministries.utils.send_mail")
+    def test_rotate_shifts_with_notify_true(
+        self,
+        mock_send_mail,
+        admin_client,
+        test_ministry,
+        ministry_member_with_email,
+        upcoming_shift,
+    ):
+        """Test that API sends emails when notify=True."""
+        url = reverse("ministry-rotate-shifts", kwargs={"pk": test_ministry.id})
+        response = admin_client.post(
+            url,
+            {"days": 14, "dry_run": False, "notify": True},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["emailed"] == 1
+        mock_send_mail.assert_called_once()


### PR DESCRIPTION
Improve email notification handling and add rotation tests

- Why:
  - Prevent silent failures and ambiguous outcomes when sending assignment emails during shift rotation.
  - Make the rotation behavior observable and testable, especially around missing addresses and slow/blocked SMTP connections.
  - Ensure rotation logic and the API endpoint are covered by deterministic tests to catch regressions.

- What it does:
  - Enhances notification logic to explicitly track and report skipped emails when a recipient has no address.
  - Returns a boolean from the email-sender helper to indicate whether an email was actually sent, allowing the caller to update metrics accurately.
  - Improves error reporting for email failures by distinguishing timeouts (including common timeout message patterns) and recording clearer error messages.
  - Reduces SMTP connect timeout used by the email backend to a shorter default to avoid long worker hangs.
  - Adds a comprehensive test suite for the rotation utility and the rotate-shifts API, covering:
    - assignment creation and dry-run behavior
    - skipped ministries with no members
    - sent/ skipped email counts when notify is true/false and when members lack emails
    - graceful handling of email send failures
    - enforcement of per-ministry assignment limits
    - authentication and role behavior for the rotate-shifts endpoint

- Benefits:
  - More reliable and actionable rotation summary reports (emails sent, skipped, and errors).
  - Faster failure detection for SMTP connectivity problems.
  - Stronger confidence in rotation and notification behavior due to tests that simulate common scenarios.

Relates to improving observability and reliability of shift rotation notifications.