### PR TITLE
Add conditional Brevo SMTP with Gmail fallback

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,3 +36,8 @@ EMAIL_HOST_PASSWORD=your-app-password-here
 
 # From email address
 DEFAULT_FROM_EMAIL=SBCC Management <your-email@gmail.com>
+
+# Brevo (Sendinblue) SMTP for production
+# Sign up at https://brevo.com and get SMTP credentials from Settings > SMTP & API
+BREVO_API_KEY=
+BREVO_SMTP_USER=

--- a/backend/sbcc/settings.py
+++ b/backend/sbcc/settings.py
@@ -259,10 +259,25 @@ SIMPLE_JWT = {
 }
 
 # Email Configuration
-EMAIL_BACKEND = "sbcc.email_backend.CustomEmailBackend"
-EMAIL_HOST = config("EMAIL_HOST", default="smtp.gmail.com")
-EMAIL_PORT = config("EMAIL_PORT", default=587, cast=int)
-EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=True, cast=bool)
-EMAIL_HOST_USER = config("EMAIL_HOST_USER", default="")
-EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default="")
+# Uses Brevo (Sendinblue) SMTP for production (works on Railway)
+# Falls back to Gmail SMTP for local development
+BREVO_API_KEY = config("BREVO_API_KEY", default="")
+
+if BREVO_API_KEY:
+    # Production: Use Brevo SMTP (works without custom domain)
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    EMAIL_HOST = "smtp-relay.brevo.com"
+    EMAIL_PORT = 587
+    EMAIL_USE_TLS = True
+    EMAIL_HOST_USER = config("BREVO_SMTP_USER", default="")
+    EMAIL_HOST_PASSWORD = BREVO_API_KEY
+else:
+    # Development: Use custom SMTP backend (Gmail)
+    EMAIL_BACKEND = "sbcc.email_backend.CustomEmailBackend"
+    EMAIL_HOST = config("EMAIL_HOST", default="smtp.gmail.com")
+    EMAIL_PORT = config("EMAIL_PORT", default=587, cast=int)
+    EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=True, cast=bool)
+    EMAIL_HOST_USER = config("EMAIL_HOST_USER", default="")
+    EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default="")
+
 DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default="SBCC Management <noreply@sbcc.org>")


### PR DESCRIPTION
Adds a conditional email configuration that prefers Brevo (Sendinblue) SMTP for production and falls back to the existing Gmail-based SMTP setup for local development.

- Enables using Brevo SMTP when a BREVO_API_KEY is present, simplifying production deployment (works on hosts that don't have a custom domain, e.g., Railway).
- Preserves the custom Gmail SMTP backend for development when BREVO_API_KEY is not set.
- Adds BREVO_API_KEY and BREVO_SMTP_USER to the example environment file so deploys can be configured easily.
- Keeps the existing default from-address behavior.

Why:
- Makes production email delivery more reliable and easier to configure without requiring a custom domain.
- Avoids disrupting local development workflows by keeping the current Gmail-based backend as the default when Brevo credentials are not supplied.

Configuration note:
- Set BREVO_API_KEY (and optionally BREVO_SMTP_USER) in environment variables to enable Brevo SMTP; otherwise the application uses the Gmail settings.