### PR TITLE
Adds FRONTEND_URL setting

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,6 +11,9 @@ CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 CORS_ALLOW_CREDENTIALS=True
 CSRF_TRUSTED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 
+# Frontend URL (used in password reset emails)
+FRONTEND_URL=http://localhost:5173
+
 # Security Flags (override to True in production)
 SECURE_SSL_REDIRECT=False
 SESSION_COOKIE_SECURE=False

--- a/backend/sbcc/settings.py
+++ b/backend/sbcc/settings.py
@@ -34,6 +34,9 @@ ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="localhost,127.0.0.1", cast=Csv(
 if not ALLOWED_HOSTS:
     ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 
+# Frontend URL for password reset emails and other links
+FRONTEND_URL = config("FRONTEND_URL", default="http://localhost:5173")
+
 
 # Application definition
 


### PR DESCRIPTION
Adds a configurable frontend URL used to build links sent from the backend (for example, password reset emails).

- Motivation
  - Ensure links generated by the backend point to the correct frontend host when frontend and backend are served separately.
  - Make the frontend host configurable rather than hardcoding URLs in email/link generation logic.

- What it does
  - Introduces a FRONTEND_URL configuration with a sensible local default.
  - Documents the variable in the example environment file so deployments can set the correct frontend origin.

- Benefits
  - Enables correct password-reset and other user-facing links across environments (local, staging, production).
  - Improves deployability and reduces surprises when the frontend is hosted on a different origin.

Notes:
- Remember to set the FRONTEND_URL to the production frontend origin in live deployments (use HTTPS in production).