### PR TITLE
Make a use Debouncing logic to other modules

### DIFF
--- a/backend/apps/visitors/views.py
+++ b/backend/apps/visitors/views.py
@@ -1,7 +1,9 @@
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
+from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -23,11 +25,17 @@ class VisitorViewSet(viewsets.ModelViewSet):
     - Check-in for attendance
     - Convert visitor to member
     - Update follow-up status
+    - Search by name, email, phone
     """
 
     queryset = Visitor.objects.select_related("converted_to_member").all()
     serializer_class = VisitorSerializer
     permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
+    filterset_fields = ["status", "follow_up_status"]
+    search_fields = ["full_name", "email", "phone"]
+    ordering_fields = ["full_name", "date_added", "status"]
+    ordering = ["-date_added"]
 
     @action(detail=True, methods=["post"])
     def check_in(self, request, pk=None):

--- a/frontend/src/features/members/components/MemberToolbar.jsx
+++ b/frontend/src/features/members/components/MemberToolbar.jsx
@@ -192,7 +192,7 @@ export const MemberToolbar = ({
         <div className="relative flex-1 min-w-[200px]">
           <HiSearch className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
           <input
-            type="search"
+            type="text"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             placeholder="Search members..."

--- a/frontend/src/features/members/pages/MembershipListPage.jsx
+++ b/frontend/src/features/members/pages/MembershipListPage.jsx
@@ -3,6 +3,7 @@ import { MemberList } from '../components/MemberList';
 import { useMembers } from '../hooks/useMembers';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { useCallback, useState, useEffect, useMemo } from 'react';
+import { useDebounce } from '../../../hooks/useDebounce';
 import { ConfirmationModal } from '../../../components/ui/Modal';
 import TrashIllustration from '../../../assets/Trash-WarmTone.svg';
 import ArchiveIllustration from '../../../assets/Archive-Illustration.svg';
@@ -38,11 +39,13 @@ export const MembershipListPage = () => {
         refresh: refreshMembers,
     } = useMembers();
 
-    // Sync search term with hook
-    const handleSearchChange = useCallback((value) => {
-        setSearchTerm(value);
-        setSearch(value);
-    }, [setSearch]);
+    // Debounced search
+    const debouncedSearchTerm = useDebounce(searchTerm, 400);
+
+    // Sync debounced search term with API
+    useEffect(() => {
+        setSearch(debouncedSearchTerm);
+    }, [debouncedSearchTerm, setSearch]);
 
     // Fetch overall stats from backend API
     const [stats, setStats] = useState({ total: 0, active: 0, inactive: 0, archived: 0 });
@@ -316,7 +319,7 @@ export const MembershipListPage = () => {
                     filters={filters}
                     setFilters={setFilters}
                     searchTerm={searchTerm}
-                    setSearchTerm={handleSearchChange}
+                    setSearchTerm={setSearchTerm}
                     onCreateClick={handleCreateMember}
                     onImportClick={() => setCsvModalOpen(true)}
                     selectionMode={selectionMode}

--- a/frontend/src/features/ministries/components/MinistryToolbar.jsx
+++ b/frontend/src/features/ministries/components/MinistryToolbar.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import {
   HiOutlinePlus,
   HiSearch,
@@ -8,6 +8,7 @@ import {
   HiCalendar,
   HiClipboardCheck,
 } from 'react-icons/hi';
+import { useDebounce } from '../../../hooks/useDebounce';
 
 // Stats display component
 const MinistryStats = ({ stats, loading }) => {
@@ -53,34 +54,23 @@ export const MinistryToolbar = ({
   onCreateClick,
   canManage,
 }) => {
-  // Debounce search
+  // Local search state for immediate UI feedback
   const [localSearch, setLocalSearch] = useState(searchTerm);
-  const debounceRef = useRef(null);
 
+  // Debounced search
+  const debouncedSearch = useDebounce(localSearch, 400);
+
+  // Sync local search with prop
   useEffect(() => {
     setLocalSearch(searchTerm);
   }, [searchTerm]);
 
-  const handleSearchChange = useCallback((e) => {
-    const value = e.target.value;
-    setLocalSearch(value);
-
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-    }
-
-    debounceRef.current = setTimeout(() => {
-      onSearchChange(value);
-    }, 300);
-  }, [onSearchChange]);
-
+  // Trigger search when debounced value changes
   useEffect(() => {
-    return () => {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-    };
-  }, []);
+    if (debouncedSearch !== searchTerm) {
+      onSearchChange(debouncedSearch);
+    }
+  }, [debouncedSearch, searchTerm, onSearchChange]);
 
   return (
     <div className="space-y-3 mb-6">
@@ -106,7 +96,7 @@ export const MinistryToolbar = ({
           <input
             type="search"
             value={localSearch}
-            onChange={handleSearchChange}
+            onChange={(e) => setLocalSearch(e.target.value)}
             placeholder="Search ministries..."
             className="w-full pl-9 pr-8 py-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-[#FDB54A]/50 focus:border-[#FDB54A] transition-all"
           />

--- a/frontend/src/features/visitors/components/VisitorsFilters.jsx
+++ b/frontend/src/features/visitors/components/VisitorsFilters.jsx
@@ -1,9 +1,29 @@
+import { useState, useEffect } from 'react';
 import { HiSearch, HiX } from 'react-icons/hi';
 import { VISITOR_STATUS_OPTIONS, FOLLOW_UP_STATUS_OPTIONS } from '../utils/constants';
+import { useDebounce } from '../../../hooks/useDebounce';
 
 export function VisitorsFilters({ filters, onFilterChange, onReset }) {
+  // Local search state for immediate UI feedback
+  const [localSearch, setLocalSearch] = useState(filters.search || '');
+
+  // Debounced search value
+  const debouncedSearch = useDebounce(localSearch, 400);
+
+  // Sync local search with filters prop
+  useEffect(() => {
+    setLocalSearch(filters.search || '');
+  }, [filters.search]);
+
+  // Trigger search when debounced value changes
+  useEffect(() => {
+    if (debouncedSearch !== (filters.search || '')) {
+      onFilterChange({ search: debouncedSearch });
+    }
+  }, [debouncedSearch, filters.search, onFilterChange]);
+
   const handleSearchChange = (e) => {
-    onFilterChange({ search: e.target.value });
+    setLocalSearch(e.target.value);
   };
 
   const handleStatusChange = (e) => {
@@ -14,7 +34,12 @@ export function VisitorsFilters({ filters, onFilterChange, onReset }) {
     onFilterChange({ follow_up_status: e.target.value });
   };
 
-  const hasActiveFilters = filters.search || filters.status || filters.follow_up_status;
+  const handleClear = () => {
+    setLocalSearch('');
+    onReset();
+  };
+
+  const hasActiveFilters = localSearch || filters.status || filters.follow_up_status;
 
   return (
     <div className="bg-white rounded-lg p-4 shadow-sm border border-gray-100 mb-6">
@@ -25,7 +50,7 @@ export function VisitorsFilters({ filters, onFilterChange, onReset }) {
           <input
             type="text"
             placeholder="Search by name, email, or phone..."
-            value={filters.search || ''}
+            value={localSearch}
             onChange={handleSearchChange}
             className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-sbcc-primary focus:border-transparent"
           />
@@ -66,7 +91,7 @@ export function VisitorsFilters({ filters, onFilterChange, onReset }) {
         {/* Reset Button */}
         {hasActiveFilters && (
           <button
-            onClick={onReset}
+            onClick={handleClear}
             className="flex items-center gap-2 px-4 py-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-lg transition-colors"
           >
             <HiX className="w-4 h-4" />

--- a/frontend/src/features/visitors/components/VisitorsFilters.jsx
+++ b/frontend/src/features/visitors/components/VisitorsFilters.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { HiSearch, HiX } from 'react-icons/hi';
 import { VISITOR_STATUS_OPTIONS, FOLLOW_UP_STATUS_OPTIONS } from '../utils/constants';
 import { useDebounce } from '../../../hooks/useDebounce';
@@ -10,17 +10,29 @@ export function VisitorsFilters({ filters, onFilterChange, onReset }) {
   // Debounced search value
   const debouncedSearch = useDebounce(localSearch, 400);
 
-  // Sync local search with filters prop
+  // Track if this is the initial mount
+  const isInitialMount = useRef(true);
+
+  // Sync local search with filters prop when it changes externally (e.g. reset)
   useEffect(() => {
-    setLocalSearch(filters.search || '');
+    if (filters.search !== undefined) {
+      setLocalSearch(filters.search || '');
+    }
   }, [filters.search]);
 
-  // Trigger search when debounced value changes
+  // Trigger API search when debounced value changes
   useEffect(() => {
+    // Skip initial mount to avoid unnecessary API call
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+
+    // Only update if the debounced search is different from current filter
     if (debouncedSearch !== (filters.search || '')) {
       onFilterChange({ search: debouncedSearch });
     }
-  }, [debouncedSearch, filters.search, onFilterChange]);
+  }, [debouncedSearch]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSearchChange = (e) => {
     setLocalSearch(e.target.value);


### PR DESCRIPTION
## Description
<!-- What does this PR do? Why is it needed? -->
This pull request introduces improved debounced search functionality across the visitors, ministries, attendance, and members features, resulting in a more responsive user experience and reduced unnecessary API calls. It also adds backend support for searching, filtering, and ordering visitors by key fields. The most important changes are grouped below:

**Backend: Enhanced Visitor Search, Filter, and Ordering**

* Added search, filter, and ordering capabilities to the `VisitorViewSet` in `views.py`, allowing API clients to search visitors by name, email, or phone, and filter/order by status and follow-up status. [[1]](diffhunk://#diff-6626d8e275d0c3153445176c9e1e3a8a3ac944f88bf9c7a6d77672b2c05059e6R3-R6) [[2]](diffhunk://#diff-6626d8e275d0c3153445176c9e1e3a8a3ac944f88bf9c7a6d77672b2c05059e6R28-R38)

**Frontend: Debounced Search Implementation**

* Refactored search input handling in `AttendanceToolbar.jsx` and `MinistryToolbar.jsx` to use a shared `useDebounce` hook for debounced search, providing immediate UI feedback and triggering API calls only after the user stops typing. [[1]](diffhunk://#diff-736052f5bc54ba63473f0c21069e69d59e6b229f5ba627de5b1d485b7e1892d1L1-R1) [[2]](diffhunk://#diff-736052f5bc54ba63473f0c21069e69d59e6b229f5ba627de5b1d485b7e1892d1R12) [[3]](diffhunk://#diff-736052f5bc54ba63473f0c21069e69d59e6b229f5ba627de5b1d485b7e1892d1L106-R123) [[4]](diffhunk://#diff-736052f5bc54ba63473f0c21069e69d59e6b229f5ba627de5b1d485b7e1892d1L159-R146) [[5]](diffhunk://#diff-736052f5bc54ba63473f0c21069e69d59e6b229f5ba627de5b1d485b7e1892d1L186-R173) [[6]](diffhunk://#diff-c7b7e1fd3a90ee745bd1e4595f0b9f2e7ff21949318776514ec1018ca8caa35cL1-R1) [[7]](diffhunk://#diff-c7b7e1fd3a90ee745bd1e4595f0b9f2e7ff21949318776514ec1018ca8caa35cR11) [[8]](diffhunk://#diff-c7b7e1fd3a90ee745bd1e4595f0b9f2e7ff21949318776514ec1018ca8caa35cL56-R73) [[9]](diffhunk://#diff-c7b7e1fd3a90ee745bd1e4595f0b9f2e7ff21949318776514ec1018ca8caa35cL109-R99)

* Added debounced search to the visitors filters component, updating the API only after the user pauses typing, and improved reset behavior to clear the search and filters together. [[1]](diffhunk://#diff-6e627cadd210d096664dcc715061e604fcc0766ecbc90a9ffac01ac61aef95baR1-R38) [[2]](diffhunk://#diff-6e627cadd210d096664dcc715061e604fcc0766ecbc90a9ffac01ac61aef95baL17-R54) [[3]](diffhunk://#diff-6e627cadd210d096664dcc715061e604fcc0766ecbc90a9ffac01ac61aef95baL28-R65) [[4]](diffhunk://#diff-6e627cadd210d096664dcc715061e604fcc0766ecbc90a9ffac01ac61aef95baL69-R106)

* Updated the members list page to use debounced search for API queries, ensuring the backend is only called after typing pauses. [[1]](diffhunk://#diff-4216b027797a172fb7ec291e67867b111a9c798ab5ce357c7187f340685a7198R6) [[2]](diffhunk://#diff-4216b027797a172fb7ec291e67867b111a9c798ab5ce357c7187f340685a7198L41-R48) [[3]](diffhunk://#diff-4216b027797a172fb7ec291e67867b111a9c798ab5ce357c7187f340685a7198L319-R322)

**Minor Improvements**

* Adjusted the search input type in `MemberToolbar.jsx` for consistency.
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Quick Checklist
- [ ] Code tested locally
- [ ] No warnings or errors
- [ ] Follows project structure (`backend/apps/`, `frontend/src/`)
- [ ] No `__pycache__`, `.env`, or `node_modules` committed
- [ ] Database migrations tested (if applicable)
- [ ] Updated documentation (if needed)

## For Major Changes Only
<details>
<summary>Click if this is a significant feature or breaking change</summary>

### Implementation Details
- Files changed:
- PRD section implemented:
- Completion: %

### Potential Issues
- What could break:

### Testing Done
- [ ] Tested on development
- [ ] Tested edge cases
- [ ] No existing functionality broken

</details>

## Screenshots
<!-- Add screenshots for UI changes -->

---
**⚠️ Critical Rules:**
- No commits to root directory (except docs/)
- No hard-coded credentials
- All apps in `backend/apps/`

**📝 Note:** @emperuna reviews all changes
