### PR TITLE
Add API health check endpoint.

### DIFF
--- a/backend/sbcc/urls.py
+++ b/backend/sbcc/urls.py
@@ -10,8 +10,12 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 
+from core.views import health_check
+
 urlpatterns = [
     path("admin/", admin.site.urls),
+    # Health check (for Railway/Render)
+    path("api/health/", health_check, name="health-check"),
     # Authentication
     path("api/auth/", include("apps.authentication.urls")),
     # Domain apps


### PR DESCRIPTION
This pull request adds a health check endpoint to the application, which can be used by deployment platforms like Railway or Render to verify that the service is running.

- API and infrastructure:
  * Added a new route `api/health/` to `backend/sbcc/urls.py` that maps to the `health_check` view for service health checks.