### PR TITLE
Refactors prayer request filtering and summaries

### DIFF
--- a/frontend/src/features/prayer-requests/pages/PrayerRequestsPage.jsx
+++ b/frontend/src/features/prayer-requests/pages/PrayerRequestsPage.jsx
@@ -79,8 +79,15 @@ const PrayerRequestsPage = () => {
   }, []);
 
   // Filter requests
+  const ACTIVE_STATUSES = ['assigned', 'in_progress', 'prayed', 'follow_up'];
+
   const filteredRequests = requests.filter((req) => {
-    const matchesStatus = statusFilter === 'all' || req.status === statusFilter;
+    let matchesStatus = statusFilter === 'all';
+    if (!matchesStatus) {
+      matchesStatus = statusFilter === 'active'
+        ? ACTIVE_STATUSES.includes(req.status)
+        : req.status === statusFilter;
+    }
     const matchesPriority = !priorityFilter || req.priority === priorityFilter;
     const matchesCategory = !categoryFilter || req.category === categoryFilter;
     const matchesSearch =
@@ -98,7 +105,7 @@ const PrayerRequestsPage = () => {
     { ...SUMMARY_CARDS[1], count: requests.filter((r) => r.status === 'pending').length },
     {
       ...SUMMARY_CARDS[2],
-      count: requests.filter((r) => ['assigned', 'in_progress', 'prayed'].includes(r.status)).length,
+      count: requests.filter((r) => ACTIVE_STATUSES.includes(r.status)).length,
     },
     { ...SUMMARY_CARDS[3], count: requests.filter((r) => r.status === 'completed').length },
   ];

--- a/frontend/src/features/prayer-requests/utils/constants.js
+++ b/frontend/src/features/prayer-requests/utils/constants.js
@@ -47,18 +47,22 @@ export const PRIORITY_METADATA = {
   low: {
     label: 'Low',
     color: 'bg-gray-100 text-gray-700 border-gray-200',
+    tint: '#6b7280',
   },
   medium: {
     label: 'Medium',
     color: 'bg-blue-100 text-blue-700 border-blue-200',
+    tint: '#3b82f6',
   },
   high: {
     label: 'High',
     color: 'bg-orange-100 text-orange-700 border-orange-200',
+    tint: '#f97316',
   },
   urgent: {
     label: 'Urgent',
     color: 'bg-red-100 text-red-700 border-red-200',
+    tint: '#ef4444',
   },
 };
 
@@ -109,6 +113,6 @@ export const DEFAULT_FORM_VALUES = {
 export const SUMMARY_CARDS = [
   { key: 'all', icon: HiClipboardList, title: 'All Requests', filterValue: 'all' },
   { key: 'pending', icon: HiClock, title: 'Pending', filterValue: 'pending' },
-  { key: 'in_progress', icon: HiHeart, title: 'In Prayer', filterValue: 'in_progress' },
+  { key: 'active', icon: HiHeart, title: 'In Prayer', filterValue: 'active' },
   { key: 'completed', icon: HiCheckCircle, title: 'Completed', filterValue: 'completed' },
 ];


### PR DESCRIPTION
Improves the filtering and summary calculations for prayer requests by:

- Introduces an `ACTIVE_STATUSES` constant to centralize the definition of active prayer request statuses.
- Updates the prayer request filtering logic to use the `ACTIVE_STATUSES` constant, allowing for easier management of active status definitions.
- Changes the "In Prayer" summary card to represent all active prayer requests (assigned, in progress, prayed, follow_up).
- Adds `tint` property for priority colors.

These changes enhance the clarity and maintainability of the code, while ensuring accurate summaries of active prayer requests.