### PR TITLE
Fix R2 Configuration

### DIFF
--- a/backend/common/storage.py
+++ b/backend/common/storage.py
@@ -28,7 +28,12 @@ class R2Storage(Storage):
             "R2_PUBLIC_URL",
         ]
 
-        missing = [s for s in required_settings if not hasattr(settings, s)]
+        missing = []
+        for s in required_settings:
+            val = getattr(settings, s, None)
+            if not val:
+                missing.append(s)
+
         if missing:
             raise ValueError(
                 f"Missing required R2 settings: {', '.join(missing)}\n"


### PR DESCRIPTION
This pull request updates static and media file storage configuration in `settings.py` to use Django's new `STORAGES` setting (introduced in Django 5.2+) and improves support for Cloudflare R2 storage. The changes modernize how static and media files are handled, replacing deprecated settings and clarifying configuration for both local and R2-backed deployments.

**Cloudflare R2 storage integration:**
* Replaces the deprecated `DEFAULT_FILE_STORAGE` setting with the new `STORAGES` dictionary, specifying `common.storage.R2Storage` for media files and `whitenoise.storage.CompressedManifestStaticFilesStorage` for static files when R2 is enabled.
* Changes the way the public R2 URL is set: now requires explicit configuration via environment variable, removing the fallback default.

**Local/development storage configuration:**
* Adds a `STORAGES` dictionary for local development, specifying `django.core.files.storage.FileSystemStorage` for media and `whitenoise.storage.CompressedManifestStaticFilesStorage` for static files.

**Static files handling:**
* Removes the top-level `STATICFILES_STORAGE` setting in favor of configuring static files backend within the new `STORAGES` dictionary.