### PR TITLE
Fix 2 configuration settings

### DIFF
--- a/backend/common/storage.py
+++ b/backend/common/storage.py
@@ -1,5 +1,5 @@
-from urllib.parse import urljoin
 import logging
+from urllib.parse import urljoin
 
 import boto3
 from botocore.client import Config
@@ -19,7 +19,7 @@ class R2Storage(Storage):
 
     def __init__(self):
         logger.debug("Initializing R2Storage backend")
-        
+
         # Check if R2 is configured
         if not getattr(settings, "USE_R2_STORAGE", False):
             raise ValueError("R2 storage is not enabled. Set USE_R2_STORAGE=true in your .env file")
@@ -46,7 +46,7 @@ class R2Storage(Storage):
             )
 
         logger.debug(f"R2 Config: bucket={settings.R2_BUCKET_NAME}")
-        
+
         self.s3_client = boto3.client(
             "s3",
             endpoint_url=settings.R2_ENDPOINT_URL,

--- a/backend/sbcc/settings.py
+++ b/backend/sbcc/settings.py
@@ -158,19 +158,19 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_DIRS = [BASE_DIR / "static"] if (BASE_DIR / "static").exists() else []
 
 # ========== Cloudflare R2 Configuration ==========
-USE_R2_STORAGE = os.getenv("USE_R2_STORAGE", "False").lower() == "true"
+USE_R2_STORAGE = config("USE_R2_STORAGE", default=False, cast=bool)
 
 if USE_R2_STORAGE:
     # R2 Storage Settings
-    R2_ACCOUNT_ID = os.getenv("R2_ACCOUNT_ID")
-    R2_ACCESS_KEY_ID = os.getenv("R2_ACCESS_KEY_ID")
-    R2_SECRET_ACCESS_KEY = os.getenv("R2_SECRET_ACCESS_KEY")
-    R2_BUCKET_NAME = os.getenv("R2_BUCKET_NAME", "sbcc-files")
+    R2_ACCOUNT_ID = config("R2_ACCOUNT_ID")
+    R2_ACCESS_KEY_ID = config("R2_ACCESS_KEY_ID")
+    R2_SECRET_ACCESS_KEY = config("R2_SECRET_ACCESS_KEY")
+    R2_BUCKET_NAME = config("R2_BUCKET_NAME", default="sbcc-files")
     R2_ENDPOINT_URL = f"https://{R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
 
     # Public URL (required - get this from R2 dashboard after enabling public access)
     # Format: https://pub-{random-hash}.r2.dev or your custom domain
-    R2_PUBLIC_URL = os.getenv("R2_PUBLIC_URL")
+    R2_PUBLIC_URL = config("R2_PUBLIC_URL")
 
     # Django 5.2+ STORAGES setting (replaces deprecated DEFAULT_FILE_STORAGE)
     STORAGES = {

--- a/backend/sbcc/settings.py
+++ b/backend/sbcc/settings.py
@@ -10,7 +10,6 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
-import os
 from datetime import timedelta
 from pathlib import Path
 

--- a/frontend/src/api/auth.api.js
+++ b/frontend/src/api/auth.api.js
@@ -34,11 +34,8 @@ export const authApi = {
   async uploadProfilePicture(file) {
     const formData = new FormData();
     formData.append('profile_picture', file);
-    const response = await apiClient.patch('/auth/me/', formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
+    // Don't set Content-Type manually - axios will auto-set multipart/form-data with boundary
+    const response = await apiClient.patch('/auth/me/', formData);
     return response.data;
   },
 

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -4,18 +4,20 @@ const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
   timeout: 10000,
 });
 
-// Request interceptor - Add auth token
+// Request interceptor - Add auth token and handle Content-Type
 apiClient.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('access_token');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
+    }
+    // Only set Content-Type for non-FormData requests
+    // FormData needs axios to auto-set with boundary
+    if (!(config.data instanceof FormData)) {
+      config.headers['Content-Type'] = 'application/json';
     }
     return config;
   },


### PR DESCRIPTION
This pull request introduces several improvements related to user profile picture handling, Cloudflare R2 storage configuration, and frontend API request handling. The main changes ensure that users can clear their profile pictures, improve logging and error handling for file storage, and make API requests more robust by handling `Content-Type` headers appropriately.

**Profile Picture and Serializer Improvements**
- Allow users to clear their profile picture by accepting `null` or an empty value in the `ProfileUpdateSerializer`, and ensure the old file is deleted from storage when cleared (`backend/apps/authentication/serializers.py`). [[1]](diffhunk://#diff-0f01162450cfa607facf24f2584b2cc25f89e9fdea9b446af4fcd72c99b3c2ddR35-R37) [[2]](diffhunk://#diff-0f01162450cfa607facf24f2584b2cc25f89e9fdea9b446af4fcd72c99b3c2ddR55-R68)

**Cloudflare R2 Storage Enhancements**
- Add logging to the `R2Storage` backend for initialization, configuration, upload success, and error cases, making debugging and monitoring easier (`backend/common/storage.py`). [[1]](diffhunk://#diff-dfe0028ff85ad810630298820e666464d86eb09d8691dcebadec6e5be655650aR2-R11) [[2]](diffhunk://#diff-dfe0028ff85ad810630298820e666464d86eb09d8691dcebadec6e5be655650aR21-R22) [[3]](diffhunk://#diff-dfe0028ff85ad810630298820e666464d86eb09d8691dcebadec6e5be655650aR48-R49) [[4]](diffhunk://#diff-dfe0028ff85ad810630298820e666464d86eb09d8691dcebadec6e5be655650aR72-R75)
- Switch from `os.getenv` to `config` for R2 storage configuration in Django settings, improving type safety and default handling (`backend/sbcc/settings.py`).

**Frontend API Improvements**
- Ensure `Content-Type` headers are only set for non-FormData requests in the Axios client, preventing issues with multipart uploads (`frontend/src/api/client.js`).
- Simplify the profile picture upload API call to let Axios automatically set the correct `Content-Type` for multipart requests (`frontend/src/api/auth.api.js`).