### PR TITLE
fix(settings): skip admin settings fetch for profile-only users

### DIFF
--- a/frontend/src/features/settings/hooks/useSettings.js
+++ b/frontend/src/features/settings/hooks/useSettings.js
@@ -2,13 +2,18 @@
 import { useState, useEffect, useCallback } from 'react';
 import { settingsApi } from '../../../api/settings.api';
 
-export const useSettings = () => {
+export const useSettings = (enabled = true) => {
   const [settings, setSettings] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState(null);
   const [saving, setSaving] = useState(false);
 
   const fetchSettings = useCallback(async () => {
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
+
     setLoading(true);
     setError(null);
 
@@ -21,11 +26,18 @@ export const useSettings = () => {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [enabled]);
 
   useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      setSettings(null);
+      setError(null);
+      return;
+    }
+
     fetchSettings();
-  }, [fetchSettings]);
+  }, [enabled, fetchSettings]);
 
   const updateSettings = useCallback(async (data) => {
     setSaving(true);

--- a/frontend/src/features/settings/pages/SettingsPage.jsx
+++ b/frontend/src/features/settings/pages/SettingsPage.jsx
@@ -15,7 +15,7 @@ import Snackbar from '../../../components/ui/Snackbar';
 
 export const SettingsPage = () => {
   const { canWrite, user } = usePermissionWarning('settings', { label: 'Settings' });
-  const { settings, loading, saving, refresh, updateSettings, uploadImage, removeImage } = useSettings();
+  const { settings, loading, saving, refresh, updateSettings, uploadImage, removeImage } = useSettings(canWrite);
   const { snackbar, hideSnackbar, showSuccess, showError } = useSnackbar();
   const [activeTab, setActiveTab] = useState(0);
 


### PR DESCRIPTION
## Description
<!-- What does this PR do? Why is it needed? -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Quick Checklist
- [x] Code tested locally
- [x] No warnings or errors
- [x] Follows project structure (`backend/apps/`, `frontend/src/`)
- [x] No `__pycache__`, `.env`, or `node_modules` committed
- [ ] Database migrations tested (if applicable)
- [ ] Updated documentation (if needed)

## For Major Changes Only
<details>
<summary>Click if this is a significant feature or breaking change</summary>

### Implementation Details
- Files changed:
- PRD section implemented:
- Completion: %

### Potential Issues
- What could break:

### Testing Done
- [ ] Tested on development
- [ ] Tested edge cases
- [ ] No existing functionality broken

</details>

## Screenshots
<!-- Add screenshots for UI changes -->

---
**⚠️ Critical Rules:**
- No commits to root directory (except docs/)
- No hard-coded credentials
- All apps in `backend/apps/`

**📝 Note:** @emperuna reviews all changes
